### PR TITLE
Refetch should not happen if no active subscribers

### DIFF
--- a/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
@@ -37,6 +37,7 @@ export const build: SubMiddlewareBuilder = ({
 
         if (
           !subscriptionSubState ||
+          Object.keys(subscriptionSubState).length === 0 ||
           !querySubState ||
           querySubState.status === QueryStatus.uninitialized
         )

--- a/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
+++ b/packages/toolkit/src/query/core/buildMiddleware/windowEventHandling.ts
@@ -39,25 +39,25 @@ export const build: SubMiddlewareBuilder = ({
         const querySubState = queries[queryCacheKey]
         const subscriptionSubState = subscriptions[queryCacheKey]
 
-        if (!subscriptionSubState || !querySubState) return
+        if (!subscriptionSubState || !querySubState) continue
 
-        if (Object.keys(subscriptionSubState).length === 0) {
-          api.dispatch(
-            removeQueryResult({
-              queryCacheKey: queryCacheKey as QueryCacheKey,
-            })
-          )
-        } else if (querySubState.status !== QueryStatus.uninitialized) {
-          const shouldRefetch =
-            Object.values(subscriptionSubState).some(
-              (sub) => sub[type] === true
-            ) ||
-            (Object.values(subscriptionSubState).every(
-              (sub) => sub[type] === undefined
-            ) &&
-              state.config[type])
+        const shouldRefetch =
+          Object.values(subscriptionSubState).some(
+            (sub) => sub[type] === true
+          ) ||
+          (Object.values(subscriptionSubState).every(
+            (sub) => sub[type] === undefined
+          ) &&
+            state.config[type])
 
-          if (shouldRefetch) {
+        if (shouldRefetch) {
+          if (Object.keys(subscriptionSubState).length === 0) {
+            api.dispatch(
+              removeQueryResult({
+                queryCacheKey: queryCacheKey as QueryCacheKey,
+              })
+            )
+          } else if (querySubState.status !== QueryStatus.uninitialized) {
             api.dispatch(refetchQuery(querySubState, queryCacheKey))
           }
         }

--- a/packages/toolkit/src/query/tests/cleanup.test.tsx
+++ b/packages/toolkit/src/query/tests/cleanup.test.tsx
@@ -72,6 +72,28 @@ test('data is removed from store after 60 seconds', async () => {
   expect(getSubStateA()).toBeUndefined()
 })
 
+test('data is removed from store if refetch without active subscribers', async () => {
+  expect(getSubStateA()).toBeUndefined()
+
+  const { unmount } = render(<UsingA />, { wrapper: storeRef.wrapper })
+  await waitFor(() =>
+    expect(getSubStateA()?.status).toBe(QueryStatus.fulfilled)
+  )
+
+  unmount()
+
+  jest.advanceTimersByTime(20000)
+
+  expect(getSubStateA()?.status).toBe(QueryStatus.fulfilled)
+
+  await storeRef.store.dispatch(api.endpoints.a.initiate())
+
+  jest.advanceTimersByTime(2000)
+
+  console.log(storeRef.store.getState())
+  expect(getSubStateA()).toBeUndefined()
+})
+
 test('data stays in store when component stays rendered while data for another component is removed after it unmounted', async () => {
   expect(getSubStateA()).toBeUndefined()
   expect(getSubStateB()).toBeUndefined()

--- a/packages/toolkit/src/query/tests/cleanup.test.tsx
+++ b/packages/toolkit/src/query/tests/cleanup.test.tsx
@@ -72,28 +72,6 @@ test('data is removed from store after 60 seconds', async () => {
   expect(getSubStateA()).toBeUndefined()
 })
 
-test('data is removed from store if refetch without active subscribers', async () => {
-  expect(getSubStateA()).toBeUndefined()
-
-  const { unmount } = render(<UsingA />, { wrapper: storeRef.wrapper })
-  await waitFor(() =>
-    expect(getSubStateA()?.status).toBe(QueryStatus.fulfilled)
-  )
-
-  unmount()
-
-  jest.advanceTimersByTime(20000)
-
-  expect(getSubStateA()?.status).toBe(QueryStatus.fulfilled)
-
-  await storeRef.store.dispatch(api.endpoints.a.initiate())
-
-  jest.advanceTimersByTime(2000)
-
-  console.log(storeRef.store.getState())
-  expect(getSubStateA()).toBeUndefined()
-})
-
 test('data stays in store when component stays rendered while data for another component is removed after it unmounted', async () => {
   expect(getSubStateA()).toBeUndefined()
   expect(getSubStateB()).toBeUndefined()


### PR DESCRIPTION
Fixes #1530

All logic that checks if there are active subscriptions in the code does a falsey check as well as a keys length check on the subscription sub state, except for the code that refetches valid queries. 
[Here is an example from the handleUnsubscribe function.](https://github.com/reduxjs/redux-toolkit/blob/master/packages/toolkit/src/query/core/buildMiddleware/cacheCollection.ts#L98)
[Here is another from invalidateTags.](https://github.com/reduxjs/redux-toolkit/blob/d4e95caa26ea1c76a1ecead8f09b1897b4444d40/packages/toolkit/src/query/core/buildMiddleware/invalidationByTags.ts#L75)
This PR includes the same check to resolve this issue. See #1530 for more information.